### PR TITLE
Zeroize AES keys in create_cipher

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ tempfile = "3.12.0"
 base64 = "0.22.1"
 aes-gcm = "0.10.3"
 typenum = "1.17.0"
+zeroize = "1.6.0"
 
 aws-config = "1.5.5"
 aws-sdk-s3 = { version = "1.46.0", features = ["behavior-version-latest"] }


### PR DESCRIPTION
## Summary
- Wrap decoded encryption key with `zeroize::Zeroizing` before constructing `Aes256Gcm`
- Add `zeroize` dependency

## Testing
- `cargo test` *(fails: failed to read `/workspace/config/Cargo.toml`)*

------
https://chatgpt.com/codex/tasks/task_e_6891db646c4c8326a9289a378eaaf719